### PR TITLE
Feature Add back button to Pipelines

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,2 @@
 nodejs 8.11.3
+postgres 10.2

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -401,4 +401,4 @@ DEPENDENCIES
   webpacker (~> 3.4.1)
 
 BUNDLED WITH
-   1.16.2
+   1.17.3

--- a/app/assets/stylesheets/admin/admin_custom.css
+++ b/app/assets/stylesheets/admin/admin_custom.css
@@ -1,0 +1,9 @@
+.back-button {
+  margin-left: 10px;
+  height: 30px;
+}
+
+.box-tools {
+  display: flex;
+  flex-direction: row;
+}

--- a/app/views/admin/pipelines/_form.html.erb
+++ b/app/views/admin/pipelines/_form.html.erb
@@ -1,6 +1,13 @@
 <div class="box box-warning">
   <div class="box-header with-border">
     <h3 class="box-title"><%= action_message %></h3>
+    <div class="box-tools">
+      <div>
+        <%= link_to admin_pipelines_path, class: "btn btn-info btn-circle back-button", data: { turbolinks: "false" } do %>
+          <i class="glyphicon glyphicon-arrow-left"></i>
+        <% end %>
+      </div>
+    </div>
   </div>
   <!-- /.box-header -->
   <div class="box-body">

--- a/app/views/admin/pipelines/show.html.erb
+++ b/app/views/admin/pipelines/show.html.erb
@@ -12,6 +12,11 @@
           </button>
         </div>
       </div>
+      <div>
+        <%= link_to admin_pipelines_path, class: "btn btn-info btn-circle back-button", data: { turbolinks: "false" } do %>
+          <i class="glyphicon glyphicon-arrow-left"></i>
+        <% end %>
+      </div>
     </div>
   </div>
 

--- a/spec/features/pipeline_spec.rb
+++ b/spec/features/pipeline_spec.rb
@@ -21,6 +21,14 @@ RSpec.describe "Pipeline", type: :feature do
     expect(page).to have_content(step2.description)
   end
 
+  scenario "user visit show and click button back" do
+    visit (admin_pipeline_path(pipeline.id))
+
+    find('.btn-info').click
+
+    expect(current_path).to eq '/admin/pipelines'
+  end
+
   scenario "user creates a new pipeline" do
     visit (new_admin_pipeline_path)
 


### PR DESCRIPTION
Closes #13 

- Add back button to pipeline show
- Add back button to pipeline form

![back-button-pipelines](https://user-images.githubusercontent.com/31258932/54054821-fe2b6700-41c9-11e9-91f1-b62970bbdfb9.gif)
